### PR TITLE
修正单词未收录导致分组内容不显示的bug

### DIFF
--- a/src/word-provider.js
+++ b/src/word-provider.js
@@ -114,7 +114,7 @@ class WordItem extends vscode.TreeItem {
   };
 
   get description() {
-    return this.data ?
+    return this.data.translation ?
       this.data.translation.replace(/\n/g, '、')
       : '未收录';
   };


### PR DESCRIPTION
例如页面上有个 tinymce 单词，左侧面板显示 T 共1个，但是展开却不显示