### PR TITLE
feat: 添加Jupyter Notebook支持

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"description": "打开源码可以自动分析所有包含的英语单词，并显示解释结果，先学单词再看代码。用了会了吧，统统都会啦！",
 	"version": "1.0.0",
 	"engines": {
-		"vscode": "^1.23.0"
+		"vscode": "^1.56.0"
 	},
 	"icon": "resources/icon.png",
 	"categories": [
@@ -132,7 +132,7 @@
 		"test": "node ./test/runTest.js"
 	},
 	"devDependencies": {
-		"@types/vscode": "^1.23.0",
+		"@types/vscode": "^1.56.0",
 		"@types/glob": "^7.1.3",
 		"@types/mocha": "^8.0.0",
 		"@types/node": "^14.0.27",

--- a/src/word-provider.js
+++ b/src/word-provider.js
@@ -96,22 +96,26 @@ class WordItem extends vscode.TreeItem {
   }
 
   get tooltip() {
-    return this.data ?
-      this.data.phonetic ?
-        [
-          `音标：[${this.data.phonetic}}]`,
-          `解释：${this.data.translation?.replace(/\n/g, '\n　　　')}`
-        ].join('\n')
-        : this.data.translation?.replace(/\n/g, '\n　　　')
-      : 'loading...';
+    if (!this.data) {
+      return 'loading...';
+    }
+    
+    if (this.data.phonetic) {
+      return [
+        `音标：[${this.data.phonetic}]`,
+        `解释：${this.data.translation ? this.data.translation.replace(/\n/g, '\n　　　') : ''}`
+      ].join('\n');
+    } else {
+      return this.data.translation ? this.data.translation.replace(/\n/g, '\n　　　') : '';
+    }
   }
 
   get iconPath() {
-    return {
-      light: path.join(__filename, '..', 'resources', 'light', 'icon.svg'),
-      dark: path.join(__filename, '..', 'resources', 'dark', 'icon.svg')
-    }
-  };
+		return {
+			light: path.join(__filename, '..', 'resources', 'light', 'icon.svg'),
+			dark: path.join(__filename, '..', 'resources', 'dark', 'icon.svg')
+		};
+	}
 
   get description() {
     return this.data && this.data.translation ?


### PR DESCRIPTION
## 功能描述
为"会了吧"扩展添加Jupyter Notebook支持，使用户可以在.ipynb文件中分析英文单词。

## 修改内容
- 支持.ipynb文件类型识别
- 添加Notebook API调用逻辑
- 修复cellAt方法不存在的问题
- 保持向后兼容性

## 测试情况
- [x] 测试普通Python文件
- [x] 测试Jupyter笔记本文件
- [x] 测试选中文本分析
- [x] 验证词典查询功能

## 截图
<img width="3840" height="2110" alt="image" src="https://github.com/user-attachments/assets/fe8efa4e-12fb-4125-82c6-51396a6ce679" />
``
